### PR TITLE
Hotfix for ImportError: cannot import name 'KDiffusionSampler'

### DIFF
--- a/scripts/steps_animation.py
+++ b/scripts/steps_animation.py
@@ -8,8 +8,11 @@ import pathlib
 import gradio as gr
 from modules import scripts
 from modules.images import save_image
-from modules.sd_samplers import sample_to_image
-from modules.sd_samplers_kdiffusion import KDiffusionSampler
+try:
+    from modules.sd_samplers_kdiffusion import KDiffusionSampler
+    from modules.sd_samplers_common import sample_to_image
+except ImportError:
+    from modules.sd_samplers import KDiffusionSampler, sample_to_image
 
 # configurable section
 video_rate = 30


### PR DESCRIPTION
The same problem was fixed in another extension:

https://github.com/AlUlkesh/sd_save_intermediate_images/issues/21